### PR TITLE
Updating the Mirador iframe tags to use mps-embed.

### DIFF
--- a/css/singleImage.css
+++ b/css/singleImage.css
@@ -1,4 +1,4 @@
-prm-full-view-service-container prm-view-online single-image div {
+single-image #iframe {
     //width:700px;
     //height:650px;
     width:100%;
@@ -17,7 +17,7 @@ span.hvdSingleImgRestrictedNote {
     padding-left:10px;
 }
 @media only print {
-    prm-full-view-service-container prm-view-online single-image div {
+    single-image #iframe {
         width:600px;
         height:500px;
         margin:0px;

--- a/css/singleImage.css
+++ b/css/singleImage.css
@@ -1,4 +1,4 @@
-.iframeClass {
+prm-full-view-service-container prm-view-online single-image div {
     //width:700px;
     //height:650px;
     width:100%;
@@ -17,7 +17,7 @@ span.hvdSingleImgRestrictedNote {
     padding-left:10px;
 }
 @media only print {
-    .iframeClass {
+    prm-full-view-service-container prm-view-online single-image div {
         width:600px;
         height:500px;
         margin:0px;

--- a/html/singleImage.html
+++ b/html/singleImage.html
@@ -10,13 +10,7 @@
         <img height="150px" width="150px" ng-show="vm.showImage" src="https://nrs.harvard.edu/urn-3:RAD.SCHL:398065?height=150&width=150"/>
     </div> -->
 
-    <!-- <iframe id="iframe" ng-show="vm.showImage" src="{{vm.imageUrl}}" class="iframeClass" allowfullscreen="true"></iframe> //-->
-    <!-- <iframe id="iframe" ng-show="vm.showImage" src="https://viewer.lib.harvard.edu/viewer/?manifestId=https%3A%2F%2Fiiif.lib.harvard.edu%2Fmanifests%2Fids%3A10274481&canvasId=https%3A%2F%2Fiiif.lib.harvard.edu%2Fmanifests%2Fids%3A10274481%2Fcanvas%2Fcanvas-10274481.json" class="iframeClass" allowfullscreen="true"></iframe> -->
-
-    <pre ng-repeat="(key, val) in this">{{key}} = {{val|json}}</pre>
-    YO2!
-    {{vm.iframeHtml}}
-
+    <iframe name="{{vm.iframeAttributes.name}}" src="{{vm.iframeAttributes.src}}" height="{{vm.iframeAttributes.height}}" width="{{vm.iframeAttributes.width}}" title="{{vm.iframeAttributes.title}}" frameborder="{{vm.iframeAttributes.frameborder}}" marginwidth="{{vm.iframeAttributes.marginwidth}}" marginheight="{{vm.iframeAttributes.marginheight}}" scrolling="{{vm.iframeAttributes.scrolling}}" allowfullscreen="{{vm.iframeAttributes.allowfullscreen}}"></iframe>
 
 <!--     <div ng-if="!vm.src">
         <div id="imgNotDig" class="nophoto" aria-label="{{vm.imgtitle}}" title="{{vm.imgtitle}}">Image not digitized</div>

--- a/html/singleImage.html
+++ b/html/singleImage.html
@@ -10,7 +10,7 @@
         <img height="150px" width="150px" ng-show="vm.showImage" src="https://nrs.harvard.edu/urn-3:RAD.SCHL:398065?height=150&width=150"/>
     </div> -->
 
-    <iframe name="{{vm.iframeAttributes.name}}" src="{{vm.iframeAttributes.src}}" height="{{vm.iframeAttributes.height}}" width="{{vm.iframeAttributes.width}}" title="{{vm.iframeAttributes.title}}" frameborder="{{vm.iframeAttributes.frameborder}}" marginwidth="{{vm.iframeAttributes.marginwidth}}" marginheight="{{vm.iframeAttributes.marginheight}}" scrolling="{{vm.iframeAttributes.scrolling}}" allowfullscreen="{{vm.iframeAttributes.allowfullscreen}}"></iframe>
+    <iframe id="iframe" ng-show="vm.showImage" name="{{vm.iframeAttributes.name}}" src="{{vm.iframeAttributes.src}}" height="{{vm.iframeAttributes.height}}" width="{{vm.iframeAttributes.width}}" title="{{vm.iframeAttributes.title}}" frameborder="{{vm.iframeAttributes.frameborder}}" marginwidth="{{vm.iframeAttributes.marginwidth}}" marginheight="{{vm.iframeAttributes.marginheight}}" scrolling="{{vm.iframeAttributes.scrolling}}" allowfullscreen="{{vm.iframeAttributes.allowfullscreen}}"></iframe>
 
 <!--     <div ng-if="!vm.src">
         <div id="imgNotDig" class="nophoto" aria-label="{{vm.imgtitle}}" title="{{vm.imgtitle}}">Image not digitized</div>

--- a/html/singleImage.html
+++ b/html/singleImage.html
@@ -10,7 +10,13 @@
         <img height="150px" width="150px" ng-show="vm.showImage" src="https://nrs.harvard.edu/urn-3:RAD.SCHL:398065?height=150&width=150"/>
     </div> -->
 
-    <iframe id="iframe" ng-show="vm.showImage" src="{{vm.imageUrl}}" class="iframeClass" allowfullscreen="true"></iframe>
+    <!-- <iframe id="iframe" ng-show="vm.showImage" src="{{vm.imageUrl}}" class="iframeClass" allowfullscreen="true"></iframe> //-->
+    <!-- <iframe id="iframe" ng-show="vm.showImage" src="https://viewer.lib.harvard.edu/viewer/?manifestId=https%3A%2F%2Fiiif.lib.harvard.edu%2Fmanifests%2Fids%3A10274481&canvasId=https%3A%2F%2Fiiif.lib.harvard.edu%2Fmanifests%2Fids%3A10274481%2Fcanvas%2Fcanvas-10274481.json" class="iframeClass" allowfullscreen="true"></iframe> -->
+
+    <pre ng-repeat="(key, val) in this">{{key}} = {{val|json}}</pre>
+    YO2!
+    {{vm.iframeHtml}}
+
 
 <!--     <div ng-if="!vm.src">
         <div id="imgNotDig" class="nophoto" aria-label="{{vm.imgtitle}}" title="{{vm.imgtitle}}">Image not digitized</div>

--- a/js/singleImage.js
+++ b/js/singleImage.js
@@ -24,10 +24,8 @@ angular.module('viewCustom')
             vm.localScope={'imgClass':'','loading':true,'hideLockIcon':false};
             vm.isLoggedIn=sv.getLogInID();
             vm.clientIp=sv.getClientIp();
-            vm.iframeHtml='iframe will go here!';
             vm.urn = '';
             console.log("singleImage.js");
-            console.log(vm.iframeHtml);
 
             // check if image is not empty and it has width and height and greater than 150, then add css class
             vm.$onChanges=function () {
@@ -41,7 +39,7 @@ angular.module('viewCustom')
                     //console.log('Restrict image: A user is not login or client IP address is not in  the list');
                 }
                 
-                vm.localScope={'imgClass':'','loading':true,'hideLockIcon':false, 'iframeHtml':''};
+                vm.localScope={'imgClass':'','loading':true,'hideLockIcon':false};
                 if(vm.src && vm.showImage) {
                     vm.items={};
                     vm.urn = vm.src.split('/').pop();

--- a/js/singleImage.js
+++ b/js/singleImage.js
@@ -24,7 +24,7 @@ angular.module('viewCustom')
             vm.localScope={'imgClass':'','loading':true,'hideLockIcon':false};
             vm.isLoggedIn=sv.getLogInID();
             vm.clientIp=sv.getClientIp();
-            console.log("singleImage.js");
+            //console.log("singleImage.js");
 
             // check if image is not empty and it has width and height and greater than 150, then add css class
             vm.$onChanges=function () {

--- a/js/singleImage.js
+++ b/js/singleImage.js
@@ -24,7 +24,6 @@ angular.module('viewCustom')
             vm.localScope={'imgClass':'','loading':true,'hideLockIcon':false};
             vm.isLoggedIn=sv.getLogInID();
             vm.clientIp=sv.getClientIp();
-            vm.urn = '';
             console.log("singleImage.js");
 
             // check if image is not empty and it has width and height and greater than 150, then add css class

--- a/js/singleImage.js
+++ b/js/singleImage.js
@@ -24,7 +24,10 @@ angular.module('viewCustom')
             vm.localScope={'imgClass':'','loading':true,'hideLockIcon':false};
             vm.isLoggedIn=sv.getLogInID();
             vm.clientIp=sv.getClientIp();
-            //console.log("singleImage.js");
+            vm.iframeHtml='iframe will go here!';
+            vm.urn = '';
+            console.log("singleImage.js");
+            console.log(vm.iframeHtml);
 
             // check if image is not empty and it has width and height and greater than 150, then add css class
             vm.$onChanges=function () {
@@ -38,9 +41,21 @@ angular.module('viewCustom')
                     //console.log('Restrict image: A user is not login or client IP address is not in  the list');
                 }
                 
-                vm.localScope={'imgClass':'','loading':true,'hideLockIcon':false};
+                vm.localScope={'imgClass':'','loading':true,'hideLockIcon':false, 'iframeHtml':''};
                 if(vm.src && vm.showImage) {
-                    const url = sv.getHttps(vm.src) + '?buttons=Y';
+                    vm.items={};
+                    vm.urn = vm.src.split('/').pop();
+                    const restUrl = 'https://localhost:23018/api/nrs'
+                    var params={'urn':vm.urn,'prod':1}
+                    sv.getAjax(restUrl,params,'get')
+                    .then(function (result) {
+                        vm.items=result.data;
+                        vm.iframeHtml = vm.items.html;
+                        console.log('iframeHtml: '+vm.iframeHtml);
+                    },function (err) {
+                        console.log(err);
+                    });
+                    const url = sv.getHttps(vm.src) + '?buttons=y';
                     vm.imageUrl = $sce.trustAsResourceUrl(url);
                 }
                 vm.localScope.loading=false;

--- a/js/singleImage.js
+++ b/js/singleImage.js
@@ -45,13 +45,24 @@ angular.module('viewCustom')
                 if(vm.src && vm.showImage) {
                     vm.items={};
                     vm.urn = vm.src.split('/').pop();
-                    const restUrl = 'https://localhost:23018/api/nrs'
+                    const restUrl = 'https://embed.lib.harvard.edu/api/nrs'
                     var params={'urn':vm.urn,'prod':1}
                     sv.getAjax(restUrl,params,'get')
                     .then(function (result) {
                         vm.items=result.data;
                         vm.iframeHtml = vm.items.html;
-                        console.log('iframeHtml: '+vm.iframeHtml);
+                        const doc = new DOMParser().parseFromString(vm.iframeHtml, 'text/html');
+                        const element = doc.body.children[0];
+                        vm.iframeAttributes = {};
+                        for (var i = 0; i < element.attributes.length; i++) {
+                            var attrib = element.attributes[i];
+                            if (attrib.name == 'src') {
+                                vm.iframeAttributes[attrib.name] = $sce.trustAsResourceUrl(attrib.value);
+                            }
+                            else {
+                                vm.iframeAttributes[attrib.name] = attrib.value;  
+                            }
+                        }                 
                     },function (err) {
                         console.log(err);
                     });


### PR DESCRIPTION
**Updating the Mirador iframe tags to use mps-embed.**
* * *

**JIRA Ticket**: [LTSVIEWER-286](https://at-harvard.atlassian.net/browse/LTSVIEWER-286)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
- [Project Charter](https://wiki.harvard.edu/confluence/pages/viewpage.action?pageId=310423634)
- [mps-embed Wiki](https://wiki.harvard.edu/confluence/display/LibraryTechServices/SysDev+-+MPS+Viewer+-+Embed)

# What does this Pull Request do?
This adds an API call to mps-embed which returns an oEmbed response that is used to populate the values in the iframe tag for displaying the Mirador Viewer.

# How should this be tested?

mps-embed only affects items in HOLLIS that are single images. It also does not change the way thumbnails are displayed.

The easiest way to test this would be to search for any items in the catalog and add a filter for “Resource Type” of “Images”, then clicking on the items to bring up the item detail modal window.

**All single images should display in the Mirador 2 Viewer and look exactly the same as they do on HOLLIS production.**

If images are restricted and you are not logged in it should not display the image. It doesn’t look great, but the functionality is the same in HOLLIS production and has not been changed with this update. It will function the exact same way.

Viewing the source code in a browser console, you should be able to tell that it is using mps-embed to render Mirador by looking at the iframe code. mps-embed adds additional attributes to the iframe tag and uses an NRS URLthat ends in :VIEW. Production currently uses an NRS URL that ends in ?button=Y.  Examples below:

OLD (PRODUCTION):
`<iframe id="iframe" ng-show="vm.showImage" src="https://nrs.harvard.edu/urn-3:FHCL:640088?buttons=Y" class="iframeClass" allowfullscreen="true" aria-hidden="false"></iframe>`

NEW (QA SANDBOX):
`<iframe id="iframe" ng-show="vm.showImage" name="mps-embed-nrs" title="" marginwidth="0" marginheight="0" scrolling="no" allowfullscreen="" aria-hidden="false" src="https://nrs.harvard.edu/urn-3:FHCL:640088:VIEW" width="100%" height="100%" frameborder="0"></iframe>
`

# Interested parties
@mferrarini 